### PR TITLE
add unit tests for HTTPCompressHandler.

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -47,7 +47,7 @@ func (pool *DeflatePool) GetWriter(dst io.Writer) (writer *flate.Writer) {
 // Don't close the writer, Flush will be called before returning
 // it to the pool.
 func (pool *DeflatePool) ReturnWriter(writer *flate.Writer) {
-	writer.Flush()
+	writer.Close()
 	pool.mutex.Lock()
 	pool.writers = append(pool.writers, writer)
 	pool.mutex.Unlock()
@@ -93,7 +93,7 @@ func (pool *GzipPool) GetWriter(dst io.Writer) (writer *gzip.Writer) {
 // Don't close the writer, Flush will be called before returning
 // it to the pool.
 func (pool *GzipPool) ReturnWriter(writer *gzip.Writer) {
-	writer.Flush()
+	writer.Close()
 	pool.mutex.Lock()
 	pool.writers = append(pool.writers, writer)
 	pool.mutex.Unlock()

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,80 @@
+package dry
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPCompressHandlerFunc(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		handlerFunc := HTTPCompressHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "hello world!")
+		})
+
+		request, err := http.NewRequest("GET", "/foobar", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed: %v", err)
+		}
+		request.Header.Set("Accept-Encoding", "gzip, deflate")
+		responseWriter := httptest.NewRecorder()
+
+		handlerFunc.ServeHTTP(responseWriter, request)
+
+		t.Logf("responseWriter.Body = %v", responseWriter.Body.Bytes())
+
+		reader, err := gzip.NewReader(responseWriter.Body)
+		if err != nil {
+			t.Fatalf("gzip.NewReader failed: %v", err)
+		}
+
+		readData, err := ioutil.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("Reading from body failed: %v", err)
+		}
+
+		if string(readData) != "hello world!" {
+			t.Fatalf("Body content: expected \"hello world!\", got %s instead.", string(readData))
+		}
+	}
+}
+
+func TestHTTPCompressHandler(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		handler := &HTTPCompressHandler{&helloWorldHandler{}}
+
+		request, err := http.NewRequest("GET", "/foobar", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest failed: %v", err)
+		}
+		request.Header.Set("Accept-Encoding", "gzip")
+		responseWriter := httptest.NewRecorder()
+
+		handler.ServeHTTP(responseWriter, request)
+
+		t.Logf("responseWriter.Body = %v", responseWriter.Body.Bytes())
+
+		reader, err := gzip.NewReader(responseWriter.Body)
+		if err != nil {
+			t.Fatalf("gzip.NewReader failed: %v", err)
+		}
+
+		readData, err := ioutil.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("Reading from body failed: %v", err)
+		}
+
+		if string(readData) != "hallo welt." {
+			t.Fatalf("Body content: expected \"hallo welt.\", got %s instead.", string(readData))
+		}
+	}
+}
+
+type helloWorldHandler struct{}
+
+func (h *helloWorldHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "hallo welt.")
+}


### PR DESCRIPTION
This adds unit tests for HTTPCompressHandler and its wrapper
HTTPCompressHandlerFunc. With these unit tests, a bug in the
GzipPool and the DeflatePool were identified where the data
written to a gzip.Writer resp. deflate.Writer wasn't completely
written, thus making decompression for the client side impossible
because some bytes were missing.
