### PR TITLE
Minor improvements

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -140,7 +140,7 @@ func BytesTail(data []byte, numLines int) (lines []string, rest []byte) {
 func BytesMap(f func(byte) byte, data []byte) []byte {
 	size := len(data)
 	result := make([]byte, size, size)
-	for i, _ := range data {
+	for i := 0; i < size; i++ {
 		result[i] = f(data[i])
 	}
 	return result
@@ -149,9 +149,9 @@ func BytesMap(f func(byte) byte, data []byte) []byte {
 // Filter out all bytes where the function does not return true.
 func BytesFilter(f func(byte) bool, data []byte) []byte {
 	result := make([]byte, 0, 0)
-	for i, _ := range data {
-		if f(data[i]) {
-			result = append(result, data[i])
+	for _, element := range data {
+		if f(element) {
+			result = append(result, element)
 		}
 	}
 	return result

--- a/string.go
+++ b/string.go
@@ -336,7 +336,7 @@ func (s StringGroupedNumberPostfixSorter) Swap(i, j int) {
 func StringMap(f func(string) string, data []string) []string {
 	size := len(data)
 	result := make([]string, size, size)
-	for i, _ := range data {
+	for i := 0; i < size; i++ {
 		result[i] = f(data[i])
 	}
 	return result
@@ -345,9 +345,9 @@ func StringMap(f func(string) string, data []string) []string {
 // Filter out all strings where the function does not return true.
 func StringFilter(f func(string) bool, data []string) []string {
 	result := make([]string, 0, 0)
-	for i, _ := range data {
-		if f(data[i]) {
-			result = append(result, data[i])
+	for _, element := range data {
+		if f(element) {
+			result = append(result, element)
 		}
 	}
 	return result


### PR DESCRIPTION
* Looping with `for i := 0; i < size; i++` instead of `range data` should, in theory, result in one less call to `len(data)` internally.

* Using `for _, element := range data` and then `element` looks a tiny bit cleaner than using `data[i]` twice.

`go test` passes.