### PR TITLE
Getenv wrapper to return a default value if an environment variable isn't there

### DIFF
--- a/os.go
+++ b/os.go
@@ -1,0 +1,15 @@
+package dry
+
+import "os"
+
+// GetenvDefault retrieves the value of the environment variable
+// named by the key. It returns the given defaultValue if the
+// variable is not present.
+func GetenvDefault(key, defaultValue string) string {
+	ret := os.Getenv(key)
+	if ret == "" {
+		return defaultValue
+	}
+
+	return ret
+}

--- a/os_test.go
+++ b/os_test.go
@@ -1,0 +1,9 @@
+package dry
+
+import "testing"
+
+func TestGetenvDefault(t *testing.T) {
+	if GetenvDefault("GO_DRY_BOGUS_ENVIRONMENT_VARIABLE", "default") != "default" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
I'm a bit unsure whether to call this function `Getenv` or `GetenvDefault` or something else.