### PR TITLE
Update function name in documentation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,7 +26,7 @@ func Nop(dummiesIn ...interface{}) (dummyOut interface{}) {
 	return nil
 }
 
-// Error returns r as error, converting it when necessary
+// AsError returns r as error, converting it when necessary
 func AsError(r interface{}) error {
 	if r == nil {
 		return nil


### PR DESCRIPTION
The function "AsError" is documented as if it was named "Error". This patch fixes the function name in the documentation.